### PR TITLE
add support for avd emulator

### DIFF
--- a/xdl/src/main/cpp/xdl.c
+++ b/xdl/src/main/cpp/xdl.c
@@ -476,7 +476,7 @@ static xdl_t *xdl_find(const char *filename) {
   // from auxv (linker, vDSO)
   xdl_t *self = NULL;
   if (xdl_util_ends_with(filename, XDL_UTIL_LINKER_BASENAME))
-    self = xdl_find_from_auxv(AT_BASE, XDL_UTIL_LINKER_PATHNAME);
+    self = xdl_find_from_auxv(AT_BASE, xdl_get_linker_path());
   else if (xdl_util_ends_with(filename, XDL_UTIL_VDSO_BASENAME))
     self = xdl_find_from_auxv(AT_SYSINFO_EHDR, XDL_UTIL_VDSO_BASENAME);
 

--- a/xdl/src/main/cpp/xdl_iterate.c
+++ b/xdl/src/main/cpp/xdl_iterate.c
@@ -192,7 +192,7 @@ static int xdl_iterate_by_linker(xdl_iterate_phdr_cb_t cb, void *cb_arg, int fla
   uintptr_t linker_base = xdl_iterate_get_linker_base();
   if (0 != linker_base) {
     if (0 !=
-        (r = xdl_iterate_do_callback(cb, cb_arg, linker_base, XDL_UTIL_LINKER_PATHNAME, &linker_load_bias)))
+        (r = xdl_iterate_do_callback(cb, cb_arg, linker_base, xdl_get_linker_path(), &linker_load_bias)))
       return r;
   }
 

--- a/xdl/src/main/cpp/xdl_linker.c
+++ b/xdl/src/main/cpp/xdl_linker.c
@@ -229,3 +229,18 @@ void *xdl_linker_force_dlopen(const char *filename) {
     return handle;
   }
 }
+
+const char* xdl_get_linker_path(void) {
+#if defined(__arm__)
+  struct stat st;
+  if (stat("/system/lib/libndk_translation.so", &st) == 0)
+    return XDL_UTIL_LINKER_PATHNAME_ARM;
+  else
+#elif defined(__aarch64__)
+  struct stat st;
+  if (stat("/system/lib64/libndk_translation.so", &st) == 0)
+    return XDL_UTIL_LINKER_PATHNAME_ARM;
+  else
+#endif
+    return XDL_UTIL_LINKER_PATHNAME;
+}

--- a/xdl/src/main/cpp/xdl_util.h
+++ b/xdl/src/main/cpp/xdl_util.h
@@ -31,6 +31,7 @@
 #ifndef __LP64__
 #define XDL_UTIL_LINKER_BASENAME        "linker"
 #define XDL_UTIL_LINKER_PATHNAME        "/system/bin/linker"
+#define XDL_UTIL_LINKER_PATHNAME_ARM    "/system/bin/arm/linker"
 #define XDL_UTIL_APP_PROCESS_BASENAME   "app_process32"
 #define XDL_UTIL_APP_PROCESS_PATHNAME   "/system/bin/app_process32"
 #define XDL_UTIL_APP_PROCESS_BASENAME_K "app_process"
@@ -38,6 +39,7 @@
 #else
 #define XDL_UTIL_LINKER_BASENAME      "linker64"
 #define XDL_UTIL_LINKER_PATHNAME      "/system/bin/linker64"
+#define XDL_UTIL_LINKER_PATHNAME_ARM  "/system/bin/arm64/linker"
 #define XDL_UTIL_APP_PROCESS_BASENAME "app_process64"
 #define XDL_UTIL_APP_PROCESS_PATHNAME "/system/bin/app_process64"
 #endif


### PR DESCRIPTION
On the AVD emulator (x86[-64] host, arm[64] guest), arm[64] binaries/modules are supported via Android's native bridge layer (e.g. libndk_translation.so). This layer provides runtime bridging/translation for the ARM ABI in the emulator, and we observe the linker path presented in /proc/self/maps as `/system/bin/arm[64]/linker`.

Accordingly, the following function determines the linker path by checking for the presence of libndk_translation.so and works as expected both on the AVD emulator (x86[-64] host, arm[64] guest) and on real devices. Please review. Thank you.

```c
const char* xdl_get_linker_path(void) {
#if defined(__arm__)
  struct stat st;
  if (stat("/system/lib/libndk_translation.so", &st) == 0)
    return XDL_UTIL_LINKER_PATHNAME_ARM;
  else
#elif defined(__aarch64__)
  struct stat st;
  if (stat("/system/lib64/libndk_translation.so", &st) == 0)
    return XDL_UTIL_LINKER_PATHNAME_ARM;
  else
#endif
    return XDL_UTIL_LINKER_PATHNAME;
}
```

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/hexhacking/xDL/blob/master/CONTRIBUTING.md
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
